### PR TITLE
Fix window ID lookup to use existing windows instead of hardcoded 0

### DIFF
--- a/src/app/services/jit_transcoder.py
+++ b/src/app/services/jit_transcoder.py
@@ -658,6 +658,29 @@ class JITTranscoder:
 
         return None, 0.0, 0.0, None
 
+    async def find_existing_windows(
+        self, asset_hash: str, profile_hash: str
+    ) -> list[int]:
+        """
+        查找给定资产和配置的所有现有窗口ID
+
+        Args:
+            asset_hash: 资产哈希
+            profile_hash: 配置哈希
+
+        Returns:
+            list[int]: 现有窗口ID列表，按ID排序
+        """
+        await self._ensure_cache_loaded()
+
+        existing_windows = []
+        for cache_key in self.cache_index:
+            cache_asset_hash, cache_profile_hash, window_id = cache_key
+            if cache_asset_hash == asset_hash and cache_profile_hash == profile_hash:
+                existing_windows.append(window_id)
+
+        return sorted(existing_windows)
+
     async def start_background_transcoding(
         self,
         input_file: Path,


### PR DESCRIPTION
## Summary
- Fixed issue where system was hardcoded to look for transcoding info from window ID 0, which might not exist
- Added `find_existing_windows` method to discover actual cached windows for a given asset/profile combination
- Updated `serve_hls_file` endpoint to use real existing windows instead of assuming window 0

## Changes Made
- **New Method**: Added `find_existing_windows()` to `JITTranscoder` class that searches cache index for existing windows
- **Improved Logic**: Updated `serve_hls_file` to find and use actual existing window IDs for transcoding info lookup
- **Better Error Handling**: Return proper 404 error when no existing windows are found

## Test Plan
- [x] Code compiles successfully  
- [x] Passes all linting checks with ruff
- [x] Method correctly searches cache index and returns sorted window IDs
- [x] API endpoint now uses discovered windows instead of hardcoded window 0
- [x] Proper error handling for cases with no existing windows

## Technical Details
The previous implementation assumed window 0 would always exist when trying to get transcoding metadata. This could fail when:
1. Window 0 was never cached 
2. Window 0 was expired/cleaned up
3. Transcoding started from a different window

The new implementation dynamically discovers existing windows and uses the first available one for metadata lookup, making the system more robust and reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HLS playback now searches for existing transcoding windows instead of assuming a default, reducing “segment not found” errors.
  * Returns a clear 404 only when no matching transcoding window exists, improving error accuracy.
  * Uses correct start times and can trigger background transcoding when needed, improving playback continuity and startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->