### PR TITLE
perf: reduce preload window count to improve resource efficiency

### DIFF
--- a/src/app/models/session.py
+++ b/src/app/models/session.py
@@ -226,7 +226,7 @@ class PlaybackSession:
 
     # 配置
     max_windows_in_playlist: int = 10  # 播放列表中最大窗口数
-    preload_window_count: int = 2  # 预加载窗口数量
+    preload_window_count: int = 1  # 预加载窗口数量
     ttl_seconds: int = 3600  # 会话生存时间
 
     def is_expired(self) -> bool:

--- a/src/app/services/session_manager.py
+++ b/src/app/services/session_manager.py
@@ -269,14 +269,7 @@ class SessionManager:
     async def _preload_initial_windows(self, session: PlaybackSession) -> None:
         """预加载初始窗口"""
         current_window_id = session.get_current_window_id()
-        required_windows = []
-
-        # 加载当前窗口及后续几个窗口
-        for offset in range(session.preload_window_count + 1):
-            window_id = current_window_id + offset
-            required_windows.append(window_id)
-
-        await self._load_windows(session, required_windows)
+        await self._load_windows(session, [current_window_id])
 
     async def _ensure_windows_available(self, session: PlaybackSession) -> None:
         """确保所需的窗口可用"""


### PR DESCRIPTION
## Summary
- Reduced preload window count from 2 to 1 to improve resource efficiency
- Simplified initial window preloading logic to only load current window
- Removed unnecessary loop for preloading multiple windows

## Test plan
- [ ] Verify playback starts correctly with single window preload
- [ ] Confirm reduced memory usage during session initialization
- [ ] Test seamless window transitions still work properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced default preloading from two windows to one, lowering initial resource usage.
  * Initial preload now loads only the current window; subsequent windows load on demand.
  * Expected improvements to startup responsiveness and memory/bandwidth consumption.
  * Note: Navigating to the next window may trigger a brief load when first accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->